### PR TITLE
remove required tag in MapAsamOpenDrive

### DIFF
--- a/osi-proto/osi_mapasamopendrive.proto
+++ b/osi-proto/osi_mapasamopendrive.proto
@@ -3,6 +3,6 @@ option optimize_for = SPEED;
 package osi3;
 message MapAsamOpenDrive
 {
-    required string map_reference = 1;
-    required string open_drive_xml_content = 2;  
+    string map_reference = 1;
+    string open_drive_xml_content = 2;  
 }


### PR DESCRIPTION
The use of required fields is heavily discouraged (see https://protobuf.dev/programming-guides/proto2/#field-labels). Therefore we should remove the required field in the MapAsamOpenDRIVE message.